### PR TITLE
#124 Add API documentation

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_spectacular',
     'corsheaders',
     'api',
     'django_extensions',
@@ -154,7 +155,15 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
-    ]
+    ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema'
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'ConnectTheDots API',
+    'DESCRIPTION': 'Auto-generated OpenAPI 3 schema for ConnectTheDots backend',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 from datetime import timedelta

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -16,8 +16,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('api.urls'))
+    path('api/', include('api.urls')),
+    # OpenAPI schema and docs
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,8 @@ Django==5.1.7
 django-cors-headers==4.7.0
 django-extensions==3.2.3
 djangorestframework==3.15.2
+drf-spectacular==0.27.2
+drf-spectacular-sidecar==2025.2.1
 djangorestframework_simplejwt==5.5.0
 gunicorn==23.0.0
 idna==3.10


### PR DESCRIPTION
- Open API 3 documentation for listing and trying endpoints created
- Can be reached from http://URL:8000/api/docs/
<img width="1507" height="748" alt="resim" src="https://github.com/user-attachments/assets/af4f5530-ced0-4e80-8ed4-86df214f7a98" />
