### PR TITLE
#196 fix dashboard top contibuted spaces width truncated

### DIFF
--- a/frontend/src/pages/BackOffice/Overview.jsx
+++ b/frontend/src/pages/BackOffice/Overview.jsx
@@ -206,7 +206,9 @@ export default function BackOffice() {
                   display: "flex",
                   flexDirection: "column",
                   gap: "15px",
+                  width: "280px",
                   minWidth: "280px",
+                  maxWidth: "280px",
                   flexShrink: 0,
                   position: "relative"
                 }}
@@ -245,7 +247,10 @@ export default function BackOffice() {
                   color: "#1B1F3B", // Primary Text - Almost Black
                   fontSize: "18px",
                   fontWeight: "600",
-                  paddingRight: "45px" // Make room for badge
+                  paddingRight: "45px",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap"
                 }}>
                   {space.title}
                 </h4>
@@ -256,7 +261,11 @@ export default function BackOffice() {
                   color: "#646E7A", // Placeholder Text - Gray
                   lineHeight: "1.4",
                   height: "40px",
-                  overflow: "hidden"
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical"
                 }}>
                   {space.description || "No description available"}
                 </p>


### PR DESCRIPTION
Before:
<img width="1116" height="963" alt="Screenshot 2025-12-07 at 17 52 47" src="https://github.com/user-attachments/assets/6554a7d9-2d49-4a95-9d30-25c6c2d11def" />
After:
<img width="1096" height="812" alt="Screenshot 2025-12-07 at 17 56 48" src="https://github.com/user-attachments/assets/416b6329-6c39-4b0a-b4ea-64f037a9812c" />
