### PR TITLE
#220 fix disabling the summarize button when space is archived

### DIFF
--- a/frontend/src/pages/SpaceDetails.jsx
+++ b/frontend/src/pages/SpaceDetails.jsx
@@ -2301,7 +2301,7 @@ const SpaceDetails = () => {
             <button
               className="summarize-btn"
               onClick={handleAiSummarize}
-              disabled={loadingAiSummary}
+              disabled={loadingAiSummary || space.is_archived}
             >
               <span>✨</span>
               {loadingAiSummary ? 'Generating...' : 'Summarize'}


### PR DESCRIPTION
You may not click
<img width="1253" height="742" alt="Screenshot 2025-12-12 at 21 48 51" src="https://github.com/user-attachments/assets/804fcc6f-4689-42f9-aef6-9a74b9a6fc48" />
