### PR TITLE
#211 - Updated SpaceGraph and SpaceDetails components to support instance type filtering and display.

### DIFF
--- a/backend/api/management/commands/fetch_missing_p31.py
+++ b/backend/api/management/commands/fetch_missing_p31.py
@@ -1,0 +1,197 @@
+"""
+Django management command to fetch missing P31 (instance of) properties
+for existing nodes that have Wikidata IDs but no P31 properties.
+
+This is a one-time migration command that can be run safely multiple times.
+It will only fetch P31 for nodes that don't already have it.
+
+Usage:
+    python manage.py fetch_missing_p31
+    python manage.py fetch_missing_p31 --dry-run
+    python manage.py fetch_missing_p31 --limit 100
+"""
+
+from django.core.management.base import BaseCommand
+from api.models import Node, Property
+from api.wikidata import get_wikidata_properties
+from api.views import _normalize_property_value_for_storage
+import time
+
+
+class Command(BaseCommand):
+    help = 'Fetch missing P31 (instance of) properties for nodes with Wikidata IDs'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be done without making changes',
+        )
+        parser.add_argument(
+            '--limit',
+            type=int,
+            default=None,
+            help='Limit the number of nodes to process',
+        )
+        parser.add_argument(
+            '--delay',
+            type=float,
+            default=1.0,
+            help='Delay in seconds between Wikidata API calls (default: 1.0)',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        limit = options['limit']
+        delay = options['delay']
+        
+        if dry_run:
+            self.stdout.write(self.style.WARNING('DRY RUN MODE - No changes will be made'))
+        
+        nodes_with_wikidata = Node.objects.filter(
+            wikidata_id__isnull=False
+        ).exclude(wikidata_id='')
+        
+        nodes_without_p31 = []
+        nodes_with_broken_p31 = []
+        
+        for node in nodes_with_wikidata:
+            p31_props = Property.objects.filter(
+                node=node,
+                property_id='P31'
+            )
+            
+            has_p31 = p31_props.exists()
+            has_valid_p31 = p31_props.filter(value_id__isnull=False).exclude(value_id='').exists()
+            
+            if not has_p31:
+                nodes_without_p31.append(node)
+            elif not has_valid_p31:
+                nodes_with_broken_p31.append(node)
+            
+            total_needs_fix = len(nodes_without_p31) + len(nodes_with_broken_p31)
+            if limit and total_needs_fix >= limit:
+                break
+        
+        total_nodes = len(nodes_without_p31) + len(nodes_with_broken_p31)
+        
+        if total_nodes == 0:
+            self.stdout.write(self.style.SUCCESS('✓ All nodes with Wikidata IDs already have valid P31 properties!'))
+            return
+        
+        self.stdout.write(f'Found {len(nodes_without_p31)} nodes without P31 properties')
+        if nodes_with_broken_p31:
+            self.stdout.write(f'Found {len(nodes_with_broken_p31)} nodes with P31 properties but missing value data')
+        
+        if dry_run:
+            self.stdout.write('Would process the following nodes:')
+            for node in (nodes_without_p31 + nodes_with_broken_p31)[:10]:
+                node_type = 'missing P31' if node in nodes_without_p31 else 'broken P31'
+                self.stdout.write(f'  - {node.label} ({node.wikidata_id}) [{node_type}]')
+            if total_nodes > 10:
+                self.stdout.write(f'  ... and {total_nodes - 10} more')
+            return
+        
+        all_nodes_to_fix = nodes_without_p31 + nodes_with_broken_p31
+        
+        success_count = 0
+        error_count = 0
+        p31_found_count = 0
+        p31_not_found_count = 0
+        p31_fixed_count = 0
+        
+        for i, node in enumerate(all_nodes_to_fix, 1):
+            try:
+                self.stdout.write(f'[{i}/{total_nodes}] Processing: {node.label} ({node.wikidata_id})...')
+                
+                all_properties = get_wikidata_properties(node.wikidata_id)
+                
+                if not all_properties:
+                    self.stdout.write(
+                        self.style.WARNING(f'  ⚠ No properties returned from Wikidata (entity may not exist or query failed)')
+                    )
+                    success_count += 1
+                    p31_not_found_count += 1
+                    if i < total_nodes:
+                        time.sleep(delay)
+                    continue
+                
+                p31_props = [p for p in all_properties if p.get('property') == 'P31']
+                
+                if p31_props:
+                    existing_p31 = Property.objects.filter(node=node, property_id='P31')
+                    is_fixing_broken = existing_p31.exists() and not existing_p31.filter(value_id__isnull=False).exclude(value_id='').exists()
+                    
+                    if is_fixing_broken:
+                        fixed_count = 0
+                        for existing_prop in existing_p31:
+                            matching_p31 = next((p for p in p31_props if p.get('statement_id') == existing_prop.statement_id), p31_props[0])
+                            value_text, value_id = _normalize_property_value_for_storage(matching_p31.get('value'))
+                            
+                            existing_prop.value = matching_p31.get('value')
+                            existing_prop.value_text = value_text
+                            existing_prop.value_id = value_id
+                            existing_prop.property_label = matching_p31.get('property_label', 'instance of')
+                            existing_prop.save()
+                            fixed_count += 1
+                        
+                        self.stdout.write(
+                            self.style.SUCCESS(f'  ✓ Fixed {fixed_count} broken P31 property(ies)')
+                        )
+                        p31_found_count += fixed_count
+                    else:
+                        for p31 in p31_props:
+                            value_text, value_id = _normalize_property_value_for_storage(p31.get('value'))
+                            Property.objects.create(
+                                node=node,
+                                property_id='P31',
+                                statement_id=p31.get('statement_id'),
+                                property_label=p31.get('property_label', 'instance of'),
+                                value=p31.get('value'),
+                                value_text=value_text,
+                                value_id=value_id
+                            )
+                        
+                        self.stdout.write(
+                            self.style.SUCCESS(f'  ✓ Added {len(p31_props)} P31 property(ies)')
+                        )
+                        p31_found_count += len(p31_props)
+                    
+                    success_count += 1
+                else:
+                    total_props = len(all_properties)
+                    if total_props > 0:
+                        self.stdout.write(
+                            self.style.WARNING(f'  ⚠ No P31 found (entity exists with {total_props} properties, may be a class/concept)')
+                        )
+                    else:
+                        self.stdout.write(
+                            self.style.WARNING(f'  ⚠ No properties returned (entity may not exist in Wikidata)')
+                        )
+                    success_count += 1
+                    p31_not_found_count += 1
+                
+                if i < total_nodes:
+                    time.sleep(delay)
+                    
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(f'  ✗ Error: {str(e)}')
+                )
+                error_count += 1
+                continue
+        
+        # Summary
+        self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS('=' * 60))
+        self.stdout.write(self.style.SUCCESS('SUMMARY'))
+        self.stdout.write(self.style.SUCCESS('=' * 60))
+        self.stdout.write(f'Total nodes processed: {total_nodes}')
+        self.stdout.write(self.style.SUCCESS(f'Successfully processed: {success_count}'))
+        self.stdout.write(self.style.SUCCESS(f'  - Nodes with P31 found: {p31_found_count}'))
+        if p31_not_found_count > 0:
+            self.stdout.write(self.style.WARNING(f'  - Nodes without P31: {p31_not_found_count}'))
+            self.stdout.write(self.style.WARNING('    (These may be classes/concepts without instance types)'))
+        if error_count > 0:
+            self.stdout.write(self.style.ERROR(f'Errors: {error_count}'))
+        self.stdout.write(self.style.SUCCESS('=' * 60))

--- a/backend/api/tests/test_instance_types.py
+++ b/backend/api/tests/test_instance_types.py
@@ -1,0 +1,358 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from rest_framework import status
+from api.models import Space, Node, Property
+
+
+class InstanceTypeGroupEndpointTests(APITestCase):
+    """Test the instance-types endpoint with grouping functionality"""
+    
+    def setUp(self):
+        """Set up test data"""
+        self.user = User.objects.create_user(username='testuser', password='testpass')
+        self.client.force_authenticate(user=self.user)
+        
+        # Create a test space
+        self.space = Space.objects.create(
+            title='Test Space',
+            description='Test Description',
+            creator=self.user
+        )
+        
+        # Create nodes with different instance types
+        self.node_human = Node.objects.create(
+            label='Albert Einstein',
+            wikidata_id='Q937',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=self.node_human,
+            property_id='P31',
+            statement_id='Q937$statement1',
+            value_id='Q5',
+            value_text='human'
+        )
+        
+        self.node_city = Node.objects.create(
+            label='New York City',
+            wikidata_id='Q60',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=self.node_city,
+            property_id='P31',
+            statement_id='Q60$statement1',
+            value_id='Q515',
+            value_text='city'
+        )
+        
+        # Create another human node
+        self.node_human2 = Node.objects.create(
+            label='Marie Curie',
+            wikidata_id='Q7186',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=self.node_human2,
+            property_id='P31',
+            statement_id='Q7186$statement1',
+            value_id='Q5',
+            value_text='human'
+        )
+        
+        # Create node without instance type
+        self.node_no_type = Node.objects.create(
+            label='Generic Node',
+            space=self.space,
+            created_by=self.user
+        )
+    
+    def test_get_instance_groups_success(self):
+        """Test successful retrieval of instance type groups"""
+        url = f'/api/spaces/{self.space.id}/instance-types/'
+        response = self.client.get(url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('instance_groups', response.data)
+        self.assertIn('nodes_by_group', response.data)
+        
+        # Check instance groups are present
+        instance_groups = response.data['instance_groups']
+        self.assertEqual(len(instance_groups), 2)  # HUMAN and CITY groups
+        
+        # Check HUMAN group has count of 2
+        human_group = next((g for g in instance_groups if g['group_id'] == 'HUMAN'), None)
+        self.assertIsNotNone(human_group)
+        self.assertEqual(human_group['count'], 2)
+        self.assertEqual(human_group['group_label'], 'Human')
+        
+        # Check CITY group has count of 1
+        city_group = next((g for g in instance_groups if g['group_id'] == 'CITY'), None)
+        self.assertIsNotNone(city_group)
+        self.assertEqual(city_group['count'], 1)
+        self.assertEqual(city_group['group_label'], 'City')
+    
+    def test_get_instance_groups_sorted_by_count(self):
+        """Test that instance groups are sorted by count (descending)"""
+        url = f'/api/spaces/{self.space.id}/instance-types/'
+        response = self.client.get(url)
+        
+        instance_groups = response.data['instance_groups']
+        
+        # First should be HUMAN with count 2
+        self.assertEqual(instance_groups[0]['group_id'], 'HUMAN')
+        self.assertEqual(instance_groups[0]['count'], 2)
+        
+        # Second should be CITY with count 1
+        self.assertEqual(instance_groups[1]['group_id'], 'CITY')
+        self.assertEqual(instance_groups[1]['count'], 1)
+    
+    def test_get_instance_groups_nodes_mapping(self):
+        """Test that nodes_by_group correctly maps groups to node IDs"""
+        url = f'/api/spaces/{self.space.id}/instance-types/'
+        response = self.client.get(url)
+        
+        nodes_by_group = response.data['nodes_by_group']
+        
+        # HUMAN group should map to 2 node IDs
+        self.assertIn('HUMAN', nodes_by_group)
+        self.assertEqual(len(nodes_by_group['HUMAN']), 2)
+        self.assertIn(self.node_human.id, nodes_by_group['HUMAN'])
+        self.assertIn(self.node_human2.id, nodes_by_group['HUMAN'])
+        
+        # CITY group should map to 1 node ID
+        self.assertIn('CITY', nodes_by_group)
+        self.assertEqual(len(nodes_by_group['CITY']), 1)
+        self.assertIn(self.node_city.id, nodes_by_group['CITY'])
+    
+    def test_get_instance_groups_empty_space(self):
+        """Test endpoint with space that has no nodes"""
+        empty_space = Space.objects.create(
+            title='Empty Space',
+            description='No nodes',
+            creator=self.user
+        )
+        
+        url = f'/api/spaces/{empty_space.id}/instance-types/'
+        response = self.client.get(url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['instance_groups']), 0)
+        self.assertEqual(len(response.data['nodes_by_group']), 0)
+    
+    def test_get_instance_groups_unmapped_types_excluded(self):
+        """Test that unmapped instance types are excluded from results"""
+        # Create node with unmapped instance type
+        node_unmapped = Node.objects.create(
+            label='Unmapped Node',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=node_unmapped,
+            property_id='P31',
+            statement_id='unmapped$s1',
+            value_id='Q999999',  # Not in any group
+            value_text='unmapped type'
+        )
+        
+        url = f'/api/spaces/{self.space.id}/instance-types/'
+        response = self.client.get(url)
+        
+        # Should still only have 2 groups (unmapped excluded)
+        self.assertEqual(len(response.data['instance_groups']), 2)
+
+
+class NodeSerializerGroupingTests(APITestCase):
+    """Test the instance_type grouping in NodeSerializer"""
+    
+    def setUp(self):
+        """Set up test data"""
+        self.user = User.objects.create_user(username='testuser', password='testpass')
+        self.client.force_authenticate(user=self.user)
+        
+        self.space = Space.objects.create(
+            title='Test Space',
+            description='Test',
+            creator=self.user
+        )
+    
+    def test_node_with_single_instance_type(self):
+        """Test that node with single P31 property returns correct group"""
+        node = Node.objects.create(
+            label='Test Human',
+            wikidata_id='Q123',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='Q123$s1',
+            value_id='Q5',
+            value_text='human'
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        node_data = response.data[0]
+        
+        # Check instance_type field returns group info
+        self.assertIn('instance_type', node_data)
+        self.assertIsNotNone(node_data['instance_type'])
+        self.assertEqual(node_data['instance_type']['group_id'], 'HUMAN')
+        self.assertEqual(node_data['instance_type']['group_label'], 'Human')
+        self.assertIn('specific_types', node_data['instance_type'])
+        self.assertIn('Q5', node_data['instance_type']['specific_types'])
+    
+    def test_node_without_instance_type(self):
+        """Test that node without P31 property returns instance_type: null"""
+        node = Node.objects.create(
+            label='Test Node',
+            space=self.space,
+            created_by=self.user
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        node_data = response.data[0]
+        
+        # Check instance_type field exists but is None
+        self.assertIn('instance_type', node_data)
+        self.assertIsNone(node_data['instance_type'])
+    
+    def test_multiple_p31_same_group_collapses(self):
+        """Test that multiple P31 values in same group collapse to one group"""
+        node = Node.objects.create(
+            label='Istanbul',
+            wikidata_id='Q406',
+            space=self.space,
+            created_by=self.user
+        )
+        
+        # Add multiple city-related P31 properties
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s1',
+            value_id='Q1637706',  # megacity
+            value_text='megacity'
+        )
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s2',
+            value_id='Q1549591',  # big city
+            value_text='big city'
+        )
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s3',
+            value_id='Q515',  # city
+            value_text='city'
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        node_data = response.data[0]
+        
+        # Should collapse to CITY group
+        self.assertEqual(node_data['instance_type']['group_id'], 'CITY')
+        # Should include all specific types
+        self.assertEqual(len(node_data['instance_type']['specific_types']), 3)
+        self.assertIn('Q1637706', node_data['instance_type']['specific_types'])
+        self.assertIn('Q1549591', node_data['instance_type']['specific_types'])
+        self.assertIn('Q515', node_data['instance_type']['specific_types'])
+    
+    def test_multiple_p31_different_groups_uses_priority(self):
+        """Test that when node has P31 from different groups, highest priority wins"""
+        node = Node.objects.create(
+            label='Test Node',
+            space=self.space,
+            created_by=self.user
+        )
+        
+        # Add P31 from CITY (priority 85) and ADMINISTRATIVE (priority 80)
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s1',
+            value_id='Q515',  # city
+            value_text='city'
+        )
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s2',
+            value_id='Q15042037',  # administrative territorial entity
+            value_text='administrative territorial entity'
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        node_data = response.data[0]
+        
+        # CITY has higher priority (85 > 80), so should return CITY
+        self.assertEqual(node_data['instance_type']['group_id'], 'CITY')
+    
+    def test_unmapped_instance_type_returns_none(self):
+        """Test that unmapped instance types return None (hidden from filter)"""
+        node = Node.objects.create(
+            label='Unmapped Node',
+            space=self.space,
+            created_by=self.user
+        )
+        Property.objects.create(
+            node=node,
+            property_id='P31',
+            statement_id='s1',
+            value_id='Q999999',  # Not in any group
+            value_text='unmapped type'
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        node_data = response.data[0]
+        
+        # Should return None for unmapped types
+        self.assertIsNone(node_data['instance_type'])
+    
+    def test_node_serializer_backward_compatible(self):
+        """Test that all existing fields are still present (backward compatibility)"""
+        node = Node.objects.create(
+            label='Test Node',
+            wikidata_id='Q999',
+            space=self.space,
+            created_by=self.user
+        )
+        
+        url = f'/api/spaces/{self.space.id}/nodes/'
+        response = self.client.get(url)
+        
+        node_data = response.data[0]
+        
+        # Check all existing fields are still present
+        expected_fields = [
+            'id', 'label', 'wikidata_id', 'created_at', 'created_by', 
+            'created_by_username', 'space', 'country', 'city', 'district', 
+            'street', 'latitude', 'longitude', 'location_name', 'description', 
+            'is_archived', 'connection_count'
+        ]
+        
+        for field in expected_fields:
+            self.assertIn(field, node_data, f"Field '{field}' missing - breaks backward compatibility!")
+        
+        # Check new field is present
+        self.assertIn('instance_type', node_data)

--- a/backend/api/tests/test_properties.py
+++ b/backend/api/tests/test_properties.py
@@ -15,7 +15,11 @@ class PropertyAPITests(APITestCase):
         self.node = Node.objects.create(label='Test Node', wikidata_id='Q123', space=self.space, created_by=self.user)
         self.client.login(username='testuser', password='testpassword')
 
-    def test_add_node_with_properties(self):
+    @patch('api.wikidata.get_wikidata_properties')
+    def test_add_node_with_properties(self, mock_get_wikidata_properties):
+        # Mock Wikidata API to return empty list (no P31 auto-fetch)
+        mock_get_wikidata_properties.return_value = []
+        
         url = reverse('space-add-node', kwargs={'pk': self.space.pk})
         data = {
             'wikidata_entity': {'id': 'Q456', 'label': 'New Test Node'},
@@ -51,7 +55,11 @@ class PropertyAPITests(APITestCase):
         self.assertEqual(response.data[0]['statement_id'], 'Q123$statement3')
         self.assertEqual(response.data[0]['property_label'], 'instance of')
 
-    def test_update_node_properties(self):
+    @patch('api.wikidata.get_wikidata_properties')
+    def test_update_node_properties(self, mock_get_wikidata_properties):
+        # Mock Wikidata API to return empty list (no P31 auto-fetch)
+        mock_get_wikidata_properties.return_value = []
+        
         Property.objects.create(node=self.node, property_id='P18', statement_id='Q123$oldstatement')
         url = reverse('space-update-node-properties', kwargs={'pk': self.space.pk, 'node_id': self.node.pk})
         data = {

--- a/frontend/src/ConnectTheDots.css
+++ b/frontend/src/ConnectTheDots.css
@@ -584,6 +584,6 @@
 
 .main-content {
   padding: 20px;
-  max-width: 1200px;
+  max-width: 1800px;
   margin: 0 auto;
 }

--- a/frontend/src/components/CircularNode.jsx
+++ b/frontend/src/components/CircularNode.jsx
@@ -4,11 +4,27 @@ import { Handle, Position } from 'reactflow';
 const CircularNode = ({ data, selected }) => {
   const nodeSize = data.size || 80;
   const fontSize = Math.max(10, Math.min(14, Math.round(nodeSize * 0.15)));
-  const nodeColor = data.color || 'var(--color-success)';
+  const nodeColor = data.instanceTypeColor || data.color || 'var(--color-success)';
+  
+  const isFiltered = data.isFiltered || false;
+  const greyedOutColor = 'var(--color-gray-300)';
+  const greyedOutBorder = 'var(--color-gray-400)';
+  
+  const finalColor = isFiltered ? greyedOutColor : nodeColor;
+  const finalBorderColor = isFiltered ? greyedOutBorder : nodeColor;
   
   const selectedColor = selected 
-    ? `color-mix(in srgb, ${nodeColor} 100%, #000 20%)` 
-    : nodeColor;
+    ? `color-mix(in srgb, ${finalColor} 100%, #000 20%)` 
+    : finalColor;
+
+  const tooltipParts = [data.label];
+  if (data.instanceTypeLabel) {
+    tooltipParts.push(`(${data.instanceTypeLabel})`);
+  }
+  if (data.wikidata_id) {
+    tooltipParts.push(`[${data.wikidata_id}]`);
+  }
+  const tooltipText = tooltipParts.join(' ');
 
   const handleStyle = {
     opacity: 0,
@@ -20,9 +36,9 @@ const CircularNode = ({ data, selected }) => {
         width: `${nodeSize}px`,
         height: `${nodeSize}px`,
         borderRadius: "50%",
-        border: selected ? `4px solid ${nodeColor}` : `3px solid ${nodeColor}`,
-        backgroundColor: selected ? selectedColor : nodeColor,
-        color: 'var(--color-white)',
+        border: selected ? `4px solid ${finalBorderColor}` : `3px solid ${finalBorderColor}`,
+        backgroundColor: selected ? selectedColor : finalColor,
+        color: isFiltered ? 'var(--color-text-secondary)' : 'var(--color-white)',
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -33,12 +49,17 @@ const CircularNode = ({ data, selected }) => {
         textAlign: "center",
         wordBreak: "break-word",
         lineHeight: "1.2",
-        boxShadow: selected 
-          ? `0 4px 12px ${nodeColor}66` 
-          : "0 2px 8px rgba(0,0,0,0.15)",
+        boxShadow: isFiltered 
+          ? "0 1px 3px rgba(0,0,0,0.1)"
+          : selected 
+            ? `0 4px 12px ${nodeColor}66` 
+            : "0 2px 8px rgba(0,0,0,0.15)",
         transition: "all 0.2s ease",
         position: "relative",
+        opacity: isFiltered ? 0.4 : 1,
+        cursor: isFiltered ? 'default' : 'pointer',
       }}
+      title={tooltipText}
     >
       <Handle 
         type="target" 
@@ -114,6 +135,9 @@ CircularNode.propTypes = {
     longitude: PropTypes.number,
     location_name: PropTypes.string,
     description: PropTypes.string,
+    instanceTypeColor: PropTypes.string,
+    instanceTypeLabel: PropTypes.string,
+    isFiltered: PropTypes.bool
   }).isRequired,
   selected: PropTypes.bool,
 };

--- a/frontend/src/components/InstanceTypeFilter.jsx
+++ b/frontend/src/components/InstanceTypeFilter.jsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from '../contexts/TranslationContext';
+import { getGroupById } from '../config/instanceTypes';
+
+const InstanceTypeFilter = ({ 
+  instanceTypes,
+  selectedTypes,
+  onToggleType,
+  onSelectAll,
+  onDeselectAll
+}) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <div style={{
+      border: '1px solid var(--color-gray-300)',
+      borderRadius: '8px',
+      backgroundColor: 'var(--color-white)',
+      overflow: 'hidden'
+    }}>
+      {/* Header */}
+      <div
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{
+          padding: '12px 16px',
+          backgroundColor: 'var(--color-bg)',
+          borderBottom: isExpanded ? '1px solid var(--color-gray-300)' : 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center'
+        }}
+      >
+        <strong style={{ color: 'var(--color-text)' }}>
+          {t('instanceTypes.filterByType')}
+        </strong>
+        <span>{isExpanded ? '▼' : '▲'}</span>
+      </div>
+
+      {/* Content */}
+      {isExpanded && (
+        <div style={{ padding: '12px' }}>
+          {/* Action Buttons */}
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+            <button
+              onClick={onSelectAll}
+              style={{
+                flex: 1,
+                padding: '6px 12px',
+                fontSize: '12px',
+                backgroundColor: 'var(--color-success)',
+                color: 'var(--color-white)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              {t('instanceTypes.selectAll')}
+            </button>
+            <button
+              onClick={onDeselectAll}
+              style={{
+                flex: 1,
+                padding: '6px 12px',
+                fontSize: '12px',
+                backgroundColor: 'var(--color-gray-400)',
+                color: 'var(--color-white)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              {t('instanceTypes.deselectAll')}
+            </button>
+          </div>
+
+          {/* Instance Type Group List */}
+          <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+            {instanceTypes.map(type => {
+              const group = getGroupById(type.group_id);
+              const isSelected = selectedTypes.has(type.group_id);
+
+              return (
+                <div
+                  key={type.group_id}
+                  onClick={() => onToggleType(type.group_id)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: '8px',
+                    marginBottom: '4px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    backgroundColor: isSelected 
+                      ? 'var(--color-item-bg)' 
+                      : 'transparent',
+                    transition: 'background-color 0.2s'
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => onToggleType(type.group_id)}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ marginRight: '8px' }}
+                  />
+                  
+                  {/* Color Dot */}
+                  {group && (
+                    <div
+                      style={{
+                        width: '16px',
+                        height: '16px',
+                        borderRadius: '50%',
+                        backgroundColor: group.color,
+                        marginRight: '8px',
+                        border: '2px solid var(--color-gray-300)',
+                        flexShrink: 0
+                      }}
+                    />
+                  )}
+                  
+                  {/* Icon */}
+                  {group && group.icon && (
+                    <span style={{ marginRight: '6px', fontSize: '14px' }}>
+                      {group.icon}
+                    </span>
+                  )}
+                  
+                  {/* Label */}
+                  <span style={{
+                    flex: 1,
+                    fontSize: '13px',
+                    color: 'var(--color-text)'
+                  }}>
+                    {group ? t(`instanceTypes.groups.${group.id}`, { defaultValue: group.label }) : type.group_label}
+                  </span>
+                  
+                  {/* Count Badge */}
+                  <span style={{
+                    backgroundColor: 'var(--color-gray-200)',
+                    color: 'var(--color-text-secondary)',
+                    padding: '2px 8px',
+                    borderRadius: '12px',
+                    fontSize: '11px',
+                    fontWeight: '600'
+                  }}>
+                    {type.count}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+InstanceTypeFilter.propTypes = {
+  instanceTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      group_id: PropTypes.string.isRequired,
+      group_label: PropTypes.string.isRequired,
+      count: PropTypes.number.isRequired
+    })
+  ).isRequired,
+  selectedTypes: PropTypes.instanceOf(Set).isRequired,
+  onToggleType: PropTypes.func.isRequired,
+  onSelectAll: PropTypes.func.isRequired,
+  onDeselectAll: PropTypes.func.isRequired
+};
+
+export default InstanceTypeFilter;

--- a/frontend/src/components/InstanceTypeLegend.jsx
+++ b/frontend/src/components/InstanceTypeLegend.jsx
@@ -1,0 +1,121 @@
+import PropTypes from 'prop-types';
+import { useTranslation } from '../contexts/TranslationContext';
+import { getGroupById } from '../config/instanceTypes';
+
+const InstanceTypeLegend = ({ 
+  visibleTypes,
+  isVisible,
+  onToggle
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div style={{ marginTop: '16px' }}>
+      {/* Toggle Button */}
+      <button
+        onClick={onToggle}
+        style={{
+          width: '100%',
+          padding: '8px 12px',
+          backgroundColor: 'var(--color-accent)',
+          color: 'var(--color-white)',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontSize: '13px',
+          fontWeight: '600'
+        }}
+      >
+        {isVisible ? t('instanceTypes.hideLegend') : t('instanceTypes.showLegend')}
+      </button>
+
+      {/* Legend Content */}
+      {isVisible && (
+        <div style={{
+          marginTop: '8px',
+          border: '1px solid var(--color-gray-300)',
+          borderRadius: '8px',
+          backgroundColor: 'var(--color-white)',
+          padding: '12px'
+        }}>
+          <div style={{
+            fontSize: '14px',
+            fontWeight: '600',
+            marginBottom: '12px',
+            color: 'var(--color-text)'
+          }}>
+            {t('instanceTypes.legend')}
+          </div>
+
+          {visibleTypes.map(type => {
+            const group = getGroupById(type.group_id);
+            
+            return (
+              <div
+                key={type.group_id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  marginBottom: '8px'
+                }}
+              >
+                {/* Color Dot */}
+                {group && (
+                  <div
+                    style={{
+                      width: '14px',
+                      height: '14px',
+                      borderRadius: '50%',
+                      backgroundColor: group.color,
+                      marginRight: '8px',
+                      border: '2px solid var(--color-gray-300)',
+                      flexShrink: 0
+                    }}
+                  />
+                )}
+                
+                {/* Icon + Label */}
+                <span style={{ fontSize: '12px', color: 'var(--color-text)' }}>
+                  {group && group.icon && `${group.icon} `}
+                  {group ? t(`instanceTypes.groups.${group.id}`, { defaultValue: group.label }) : type.group_label}
+                </span>
+              </div>
+            );
+          })}
+
+          {/* Default Color */}
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginTop: '12px',
+            paddingTop: '8px',
+            borderTop: '1px solid var(--color-gray-200)'
+          }}>
+            <div
+              style={{
+                width: '14px',
+                height: '14px',
+                borderRadius: '50%',
+                backgroundColor: 'var(--color-success)',
+                marginRight: '8px',
+                border: '2px solid var(--color-gray-300)',
+                flexShrink: 0
+              }}
+            />
+            <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
+              {t('instanceTypes.noInstanceType')}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+InstanceTypeLegend.propTypes = {
+  visibleTypes: PropTypes.array.isRequired,
+  isVisible: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired
+};
+
+export default InstanceTypeLegend;

--- a/frontend/src/config/instanceTypes.js
+++ b/frontend/src/config/instanceTypes.js
@@ -1,0 +1,189 @@
+/**
+ * Global configuration for Wikidata instance type GROUPS (P31)
+ * 
+ * This config implements a grouping system that maps hundreds of specific
+ * Wikidata instance types into ~10 broad categories for visualization.
+ * 
+ * For example, "megacity", "big city", "port city" all map to "City" group.
+ * 
+ * Color palette is optimized for color blindness accessibility.
+ * 
+ * @example
+ * import { INSTANCE_TYPE_GROUPS, getGroupForType } from '../config/instanceTypes';
+ */
+
+// Instance type groups for visualization
+export const INSTANCE_TYPE_GROUPS = {
+  HUMAN: {
+    id: 'HUMAN',
+    label: 'Human',
+    types: ['Q5', 'Q215627'],
+    color: '#0072B2',
+    icon: '👤',
+    priority: 100,
+    description: 'Individual persons'
+  },
+  CITY: {
+    id: 'CITY',
+    label: 'City',
+    types: ['Q515', 'Q1549591', 'Q1637706', 'Q5119', 'Q200250', 'Q1093829', 'Q7930989', 'Q2514025'],
+    color: '#E69F00',
+    icon: '🏙️',
+    priority: 85,
+    description: 'Cities and urban areas'
+  },
+  COUNTRY: {
+    id: 'COUNTRY',
+    label: 'Country',
+    types: ['Q6256', 'Q3024240', 'Q859563', 'Q1520223'],
+    color: '#56B4E9',
+    icon: '🌍',
+    priority: 90,
+    description: 'Countries and sovereign states'
+  },
+  SETTLEMENT: {
+    id: 'SETTLEMENT',
+    label: 'Settlement',
+    types: ['Q486972', 'Q532', 'Q3957', 'Q5084', 'Q3191695', 'Q15221371'],
+    color: '#F0E442',
+    icon: '🏘️',
+    priority: 75,
+    description: 'Villages, towns, and small settlements'
+  },
+  ORGANIZATION: {
+    id: 'ORGANIZATION',
+    label: 'Organization',
+    types: ['Q43229', 'Q4830453', 'Q783794', 'Q891723', 'Q219577', 'Q7210356', 'Q31855', 'Q2085381', 'Q294163'],
+    color: '#D55E00',
+    icon: '🏢',
+    priority: 70,
+    description: 'Organizations, companies, and institutions'
+  },
+  GEOGRAPHIC_FEATURE: {
+    id: 'GEOGRAPHIC_FEATURE',
+    label: 'Geographic Feature',
+    types: ['Q8502', 'Q23442', 'Q4022', 'Q23397', 'Q39594', 'Q185113', 'Q39816', 'Q54050', 'Q177634'],
+    color: '#8B4513',
+    icon: '⛰️',
+    priority: 60,
+    description: 'Natural geographic features'
+  },
+  SPECIES: {
+    id: 'SPECIES',
+    label: 'Species',
+    types: ['Q16521', 'Q7432', 'Q34740', 'Q35409', 'Q36602', 'Q37517'],
+    color: '#009E73',
+    icon: '🌿',
+    priority: 50,
+    description: 'Biological taxa and species'
+  },
+  WORK: {
+    id: 'WORK',
+    label: 'Work',
+    types: ['Q11424', 'Q571', 'Q7725634', 'Q13442814', 'Q732577', 'Q2188189', 'Q386724', 'Q3305213', 'Q860861'],
+    color: '#CC79A7',
+    icon: '📄',
+    priority: 55,
+    description: 'Creative and scholarly works'
+  },
+  BUILDING: {
+    id: 'BUILDING',
+    label: 'Building',
+    types: ['Q41176', 'Q16560', 'Q44494', 'Q16970', 'Q34627', 'Q44539', 'Q33506', 'Q483110', 'Q5003624'],
+    color: '#808000',
+    icon: '🏛️',
+    priority: 65,
+    description: 'Buildings and structures'
+  },
+  ADMINISTRATIVE: {
+    id: 'ADMINISTRATIVE',
+    label: 'Administrative Division',
+    types: ['Q15042037', 'Q10864048', 'Q56061', 'Q842112', 'Q192611', 'Q174844', 'Q82794'],
+    color: '#000080',
+    icon: '🗺️',
+    priority: 80,
+    description: 'Administrative territorial entities'
+  }
+};
+export const UNKNOWN_COLOR = '#94A3B8';
+
+const TYPE_TO_GROUP_MAP = {};
+Object.values(INSTANCE_TYPE_GROUPS).forEach(group => {
+  group.types.forEach(typeId => {
+    TYPE_TO_GROUP_MAP[typeId] = group.id;
+  });
+});
+
+/**
+ * Get group for a specific Wikidata type ID
+ * @param {string} typeId - Wikidata Q-ID (e.g., 'Q515')
+ * @returns {object|null} Group object or null if not found
+ */
+export const getGroupForType = (typeId) => {
+  const groupId = TYPE_TO_GROUP_MAP[typeId];
+  return groupId ? INSTANCE_TYPE_GROUPS[groupId] : null;
+};
+
+/**
+ * Get color for a type (returns group color)
+ * @param {string} typeId - Wikidata Q-ID
+ * @returns {string} Hex color code
+ */
+export const getInstanceTypeColor = (typeId) => {
+  const group = getGroupForType(typeId);
+  return group ? group.color : UNKNOWN_COLOR;
+};
+
+/**
+ * Get group color by group ID
+ * @param {string} groupId - Group ID (e.g., 'CITY')
+ * @returns {string} Hex color code
+ */
+export const getGroupColor = (groupId) => {
+  const group = INSTANCE_TYPE_GROUPS[groupId];
+  return group ? group.color : UNKNOWN_COLOR;
+};
+
+/**
+ * Get priority for sorting (higher = more important)
+ * @param {string} typeId - Wikidata Q-ID
+ * @returns {number} Priority value
+ */
+export const getInstanceTypePriority = (typeId) => {
+  const group = getGroupForType(typeId);
+  return group ? group.priority : 0;
+};
+
+/**
+ * Priority-ordered list of group IDs (highest to lowest)
+ * @returns {string[]} Array of group IDs
+ */
+export const INSTANCE_TYPE_PRIORITY_ORDER = Object.values(INSTANCE_TYPE_GROUPS)
+  .sort((a, b) => b.priority - a.priority)
+  .map(g => g.id);
+
+/**
+ * Get all groups as an array
+ * @returns {object[]} Array of group objects
+ */
+export const getAllGroups = () => {
+  return Object.values(INSTANCE_TYPE_GROUPS);
+};
+
+/**
+ * Check if a type ID is mapped to any group
+ * @param {string} typeId - Wikidata Q-ID
+ * @returns {boolean}
+ */
+export const isTypeMapped = (typeId) => {
+  return typeId in TYPE_TO_GROUP_MAP;
+};
+
+/**
+ * Get group by group ID
+ * @param {string} groupId - Group ID (e.g., 'CITY')
+ * @returns {object|null} Group object or null
+ */
+export const getGroupById = (groupId) => {
+  return INSTANCE_TYPE_GROUPS[groupId] || null;
+};

--- a/frontend/src/hooks/useGraphData.js
+++ b/frontend/src/hooks/useGraphData.js
@@ -158,6 +158,7 @@ const useGraphData = (spaceId) => {
         longitude: node.longitude || null,
         location_name: node.location_name || null,
         description: node.description || null,
+        instance_type: node.instance_type || null,
       }));
 
       const edgesDataArray = Array.isArray(edgesData) ? edgesData : [];

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -169,6 +169,10 @@
     "nodeDetails": "Node Details",
     "edgeDetails": "Edge Details",
     "connectedNodes": "Connected Nodes",
+    "showFilters": "Show Filters",
+    "hideFilters": "Hide Filters",
+    "showSidebar": "Show Sidebar",
+    "hideSidebar": "Hide Sidebar",
     "source": "Source",
     "target": "Target",
     "wikidataProperty": "Wikidata Property",
@@ -273,6 +277,30 @@
     "showing": "Showing",
     "of": "of",
     "usersCount": "users"
+  },
+  "instanceTypes": {
+    "title": "Instance Types",
+    "filterByType": "Filter by Type",
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "legend": "Color Legend",
+    "showLegend": "Show Legend",
+    "hideLegend": "Hide Legend",
+    "noInstanceType": "No instance type",
+    "otherTypes": "Other types",
+    "filtering": "Showing",
+    "groups": {
+      "HUMAN": "Human",
+      "CITY": "City",
+      "COUNTRY": "Country",
+      "SETTLEMENT": "Settlement",
+      "ORGANIZATION": "Organization",
+      "GEOGRAPHIC_FEATURE": "Geographic Feature",
+      "SPECIES": "Species",
+      "WORK": "Work",
+      "BUILDING": "Building",
+      "ADMINISTRATIVE": "Administrative Division"
+    }
   },
   "errors": {
     "failedToLoadProfile": "Failed to load profile data",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -169,6 +169,10 @@
     "nodeDetails": "Düğüm Detayları",
     "edgeDetails": "Bağlantı Detayları",
     "connectedNodes": "Bağlı Düğümler",
+    "showFilters": "Filtreleri Göster",
+    "hideFilters": "Filtreleri Gizle",
+    "showSidebar": "Kenar Çubuğunu Göster",
+    "hideSidebar": "Kenar Çubuğunu Gizle",
     "source": "Kaynak",
     "target": "Hedef",
     "wikidataProperty": "Wikidata Özelliği",
@@ -273,6 +277,30 @@
     "showing": "Gösteriliyor",
     "of": "/",
     "usersCount": "kullanıcı"
+  },
+  "instanceTypes": {
+    "title": "Örnek Türleri",
+    "filterByType": "Türe Göre Filtrele",
+    "selectAll": "Tümünü Seç",
+    "deselectAll": "Tümünü Kaldır",
+    "legend": "Renk Açıklaması",
+    "showLegend": "Açıklamayı Göster",
+    "hideLegend": "Açıklamayı Gizle",
+    "noInstanceType": "Örnek türü yok",
+    "otherTypes": "Diğer türler",
+    "filtering": "Gösteriliyor",
+    "groups": {
+      "HUMAN": "İnsan",
+      "CITY": "Şehir",
+      "COUNTRY": "Ülke",
+      "SETTLEMENT": "Yerleşim",
+      "ORGANIZATION": "Organizasyon",
+      "GEOGRAPHIC_FEATURE": "Coğrafi Özellik",
+      "SPECIES": "Tür",
+      "WORK": "Eser",
+      "BUILDING": "Bina",
+      "ADMINISTRATIVE": "İdari Bölüm"
+    }
   },
   "errors": {
     "failedToLoadProfile": "Profil verileri yüklenemedi",

--- a/infra/docker-compose.mainprod.yaml
+++ b/infra/docker-compose.mainprod.yaml
@@ -5,6 +5,7 @@ services:
       dockerfile: ./Dockerfile
     command: sh -c " python manage.py makemigrations &&
             python manage.py migrate &&
+            python manage.py fetch_missing_p31 & 
             gunicorn backend.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - ../backend:/app

--- a/infra/docker-compose.prod.yaml
+++ b/infra/docker-compose.prod.yaml
@@ -5,6 +5,7 @@ services:
       dockerfile: ./Dockerfile
     command: sh -c " python manage.py makemigrations &&
             python manage.py migrate &&
+            python manage.py fetch_missing_p31 & 
             gunicorn backend.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - ../backend:/app

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       dockerfile: ./Dockerfile
     command: sh -c " python manage.py makemigrations &&
             python manage.py migrate &&
+            python manage.py fetch_missing_p31 & 
             gunicorn backend.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - ../backend:/app


### PR DESCRIPTION
- Introduced `instance_type` field in NodeSerializer to fetch the highest priority instance type group for nodes.
- Implemented `get_instance_types` action in SpaceViewSet to retrieve instance type groups and their counts for nodes in a space.
- Enhanced node creation and update processes to auto-fetch and store all P31 values if none are selected.
- Added translations for instance type-related UI elements.

<img width="1512" height="707" alt="resim" src="https://github.com/user-attachments/assets/84c92d34-f006-46d5-98e1-78ed0e5db7ae" />
