### PR TITLE
#237 fix edge property search dropdown cancel

### DIFF
--- a/frontend/src/components/PropertySearch.jsx
+++ b/frontend/src/components/PropertySearch.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "../contexts/TranslationContext";
 import useWikidataPropertySearch from "../hooks/useWikidataPropertySearch";
+import useClickOutside from "../hooks/useClickOutside";
 import "./PropertySearch.css";
 
 const PropertySearch = ({ onSelect, initialLabel }) => {
@@ -15,6 +16,11 @@ const PropertySearch = ({ onSelect, initialLabel }) => {
     useWikidataPropertySearch();
   const isSelectingEdgeRef = useRef(false);
   const hasInteractedRef = useRef(false);
+  const containerRef = useClickOutside(() => {
+    if (searchResults.length > 0) {
+      clearSearch();
+    }
+  });
 
   useEffect(() => {
     if (selectedProperty) {
@@ -58,7 +64,7 @@ const PropertySearch = ({ onSelect, initialLabel }) => {
   };
 
   return (
-    <div className="property-search-container">
+    <div ref={containerRef} className="property-search-container">
       <input
         type="text"
         value={searchTerm}


### PR DESCRIPTION
You can now exit from the dropdown and add free text.
<img width="1603" height="953" alt="Screenshot 2025-12-14 at 00 41 46" src="https://github.com/user-attachments/assets/b496b6c5-4523-4030-8ba9-a4b4879cdccd" />
